### PR TITLE
Minutes as files with archive

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,6 @@
 theme: jekyll-theme-minimal
 title: GA4GH - Genomic Knowledge Standards
+future: true
 navigation_categories:
   variant_annotation: Variant Annotation
   variant_representation: Variant Representation

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,40 +14,43 @@
 
   <style type="text/css">
 
-    header {
-      padding-right: 30px;
-    }
-    header h4 {
-      display: block;
-      margin-top: 4px;
-      margin-bottom: 2px;
-    }
-    header div {
-      margin-bottom: 2px;
+    div {
       display: block;
       clear: both;
     }
-    header div.sublink {
+
+    div.navboxleft {
+      padding-right: 30px;
+      padding-top: 20px;
+      padding-bottom: 0px;
+    }
+
+    h4.navleft {
+      margin-top: 0px;
+      margin-bottom: 3px;
+    }
+
+    div.header_sublink {
       padding-left: 8px;
       font-size: 0.9em;
+      margin-bottom: 2px;
     }
-    header p {
-      margin-top: 0px;
-      margin-bottom: 4px;
-    }
+
     li {
       margin-top: 0px;
       margin-bottom: 2px;
     }
+
     section {
       width: 540px;
     }
     section h4 {
-      margin-bottom: 10px;
+      margin-bottom: 8px;
     }
 
     section h2,h3 {
-      margin-bottom: 20px;
+      margin-top: 10px;
+      margin-bottom: 12px;
     }
     section p {
       margin-top: 0px;
@@ -56,13 +59,12 @@
 
     section div.excerpt {
       display: block;
-      padding: 3px;
+      padding: 3px 3px 3px 10px;
       margin-bottom: 5px;
       background-color: #fcfcfc;
       font-size: 0.8em;
       border-radius: 10px;
       border: 1px solid #e5e5e5;
-      /* border-radius: 10px; */
     }
 
   </style>
@@ -73,21 +75,27 @@
   <div class="wrapper">
     <header id="header">
 
-      <h1 style="margin-bottom: 6px;"> <a href="{{ site.github.url | default: "/index.html" }}">GA4GH::GKS</a></h1>
-      <div style="margin-bottom: 20px;">{{ site.description | default: site.github.project_tagline }}</div>
+      <h1 style=""> <a href="{{ site.github.url | default: "/index.html" }}">GA4GH::GKS</a></h1>
+      <div style="">{{ site.description | default: site.github.project_tagline }}</div>
+
+  <div class="navboxleft">
 
 <!-- ######################################################################  -->
 <!--         navigation_categories from _config.yaml                         -->
 <!-- ######################################################################  -->
 
 {% for this_category in site.navigation_categories %}
-      <h4><a href="/{{ this_category[0] }}.html">{{ this_category[1] }}</a></h4>
-  {% if page.category contains this_category[0] %}
+  {% assign cat_label = this_category[1] %}
+  {% assign cat_key = this_category[0] %}
+      <h4 class="navleft"><a href="/{{ this_category[0] }}.html">{{ cat_label }}</a></h4>
+  {% if page.category contains cat_key %}
 <!-- All matching post -->
-    {% for post in site.categories.this_category[0] %}
-      <div class="sublink" >
+    {% for post in site.posts %}
+      {% if post.category contains cat_key %}     
+      <div class="header_sublink" >
         <a href="{{ post.url }}">{{ post.title }}</a>
       </div>
+      {% endif %}
     {% endfor %}
   {% endif %}
 {% endfor %}
@@ -99,19 +107,25 @@
 <!-- ######################################################################  -->
 <!--                           Static Links                                  -->
 <!-- ######################################################################  -->
-      <h4><a href="https://github.com/ga4gh-gks/">GA4GH-GKS Repositories</a></h4>
+      <h4 class="navleft"><a href="https://github.com/ga4gh-gks/">GA4GH-GKS Repositories</a></h4>
 
-      <h4>Related Projects</h4>
+</div>
+
+<div class="navboxleft">
+
+      <h4 class="navleft">Related Projects</h4>
 <!-- Moving away from the standard template to a custom/static version -->
-      <div class="sublink">
+      <div class="header_sublink">
         <a href="https://github.com/ga4gh/">GA4GH Projects</a>
       </div>
-      <div class="sublink">
+      <div class="header_sublink">
         <a href="https://github.com/ga4gh-metadata/">GA4GH Metadata</a>
       </div>
-      <div class="sublink">
+      <div class="header_sublink">
         <a href="https://github.com/ga4gh/large-scale-genomics-wiki/wiki/">GA4GH Large Scale Genomics</a>
       </div>
+
+</div>
 
 <!-- ######################################################################  -->
 <!--                          / Static Links                                 -->
@@ -121,9 +135,13 @@
 <!--                            Github Edit                                  -->
 <!-- ######################################################################  -->
 
-      <div class="sublink" style="margin-left: 0px; margin-top: 10px; color: #ccc; ">
+<div class="navboxleft">
+
+      <div class="header_sublink" style="margin-left: 0px; margin-top: 10px; color: #ccc; ">
         <a href="{{site.github.repository_url}}/blob/master/{{page.path}}" style="text-decoration: none; color: #ccc;">Edit this page</a>
       </div>
+
+</div>
 
 <!-- ######################################################################  -->
 <!--                           / Github Edit                                 -->

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -109,6 +109,9 @@
       <div class="sublink">
         <a href="https://github.com/ga4gh-metadata/">GA4GH Metadata</a>
       </div>
+      <div class="sublink">
+        <a href="https://github.com/ga4gh/large-scale-genomics-wiki/wiki/">GA4GH Large Scale Genomics</a>
+      </div>
 
 <!-- ######################################################################  -->
 <!--                          / Static Links                                 -->

--- a/_posts/2018-04-16-minutes-variant_representation.md
+++ b/_posts/2018-04-16-minutes-variant_representation.md
@@ -1,0 +1,52 @@
+---
+title:  "VarRep Minutes 2018-04-16"
+date: 2018-04-16
+layout: default
+category:
+  - variant_representation_minutes
+---
+
+## Var Rep Working Call (equiv/analog vmc examples)
+##### Chairs: Larry Babb
+##### Attendees “Name (Affiliation)”
+
+* Michael Baudis
+* Piotr Pawliczek (ClinGen)
+* Andy Yates (EMBL-EBI)
+* Melissa Cline (UCSC)
+* Brian Walsh(OHSU)
+* Deepak Unni (LBNL)
+* Crista Martin
+* Ronak Patel (BCM/ClinGen)
+* Sarah Hunt (EMBL-EBI)
+* Tristan Nelson
+* Rishi Nag (GA4GH)
+* Karen Eilbeck (U of Utah, Sequence Ontology)
+* Bob Freimuth (mayo Clinic)
+* Bizon
+
+#### Minutes
+
+- LB: - opening discussion about VMC => transition to adoption
+- MB: - move forward w/ adoption…
+- LB, MB: - discussions about Git, parceling out topics to work on there (issues etc)
+- BW: - are relationships part of the spec? -> example for extension work mode
+- LB: - everybody contribute …
+- LB: - [use cases/examples](https://docs.google.com/spreadsheets/d/1o85GwckB_peOOEZzP608Nz0X7_9NUPvqrJkKL5A9JCQ/edit?usp=sharing) … important for tracking, also for later discussions
+- Use case based review of VMC for coverage of the needed concepts:
+- VMC => digests expected to be possible (required? MB) for all levels (seq, loc, allele, hap, genotype)
+- Equivalence example of deletions of different base position in repetitive region
+- MB: points to lack of reference base representation (LB: design decision)
+- BW: computability of identifiers when using different accessions representing same sequence … LB, PP: only if compute over sequence => same identifier; PP: however, transcripts w/ same sequence may be different based on start codon
+- BW: start with most simple example for representation and add on that
+- Are bundles the same if output sequence is, or only if all elements are (as per current VMC… symmetric/transitive/reflexive)? PP, LB … 
+- PP: “analogue relation” if same sequence output; not covered yet => 2nd type of equivalence in resulting sequence (LB)
+- LB: calling the “output of an allele” something different?
+- BF: Examples good, needed for define e.g. “types of equivalence” => go through, look for emerging patterns
+- Next: same accessions on different versions (37 vs. 38):
+- MB: same - same; even more than equivalence; but comp. Differences from changes in ref/alignment
+- LB, PP: differences from alignments/aligners; “aligned allele equivalence”
+
+=> More detailed notes from working call can be found [here](https://docs.google.com/document/d/1exzE9hLaMeYsQ6Uu5OQOJbO_hJjyBWu--vqdboWHLYI/edit#heading=h.tms7m01cjme3). 
+
+=> [**Archive**](/variant_representation_minutes.html) of previous meeting minutes

--- a/_posts/2018-04-23-minutes-variant_representation.md
+++ b/_posts/2018-04-23-minutes-variant_representation.md
@@ -1,0 +1,50 @@
+---
+title:  "VarRep Minutes 2018-04-23"
+date: 2018-04-23
+layout: default
+category:
+  - variant_representation_minutes
+---
+
+### Variant Representation (equiv/analog vmc examples)
+##### Chairs: Larry Babb, Michael Baudis
+##### Attendees “Name (Affiliation)”: Piotr Pawliczek (ClinGen), Chris Bizon, Cristina Yenyxe González (EMBL-EBI), Tristan Nelson, Reece Hart, Zhenyu Zhang (GDC / UChicago), Deepak Unni, Shawn Rynearson and Karen Eilbeck (U of U)
+
+
+##### Minutes:
+
+- Michael: Set up a [gitub organisation](https://github.com/ga4gh-gks), have a dev site and a place where future repositories could be put.  Will be filled out. - **ACTION** All should suggest what can be put here.
+- Larry: All links to Google docs will be placed here.
+- Michael:  How much of this should be open and visible?
+- Larry: There is currently a google drive where this is currently organized.
+- Michael: **ACTION** Melissa to make a list of important + public docs
+- 
+- Larry: Recap of past meetings.  https://docs.google.com/document/d/1UTjAB-Nh2t7UCCTVl1VdoXTP8HK0Y4LmDEAvqUBMOOY/edit
+- [Slides here](https://drive.google.com/file/d/1Qw-_rC2tLNiKJc6WwjCl0H4T_tq6DCdi/view)
+
+- Proposed talking about aligning build 37 sequence…***
+- Importance of strandedness and directionality, HL7 went with Watson and Crick instead of +/-.
+- If you look at deletions on the Watson vs Crick strand, right shifting changes things.***
+- Reece:  Variant normalization is good for preventing annotation from leaking across into representation.
+- Projecting a variant from a - strand to the + strand needs to be normalized again.  A duplication 5’ on the genome gets renormalized as ***. 
+- 
+- Karen: Why go back to Watson and Crick?  Everything in bioinformatics uses +/-.
+- Larry: Let’s stick with +/-, will feedback to Bob re HL7.
+- 
+- Larry to Reece: VMC Bundles, they are just a mechanism to package things in a message, correct?
+- Reece: Yes.  The intention was to create an internally consistent set of data.  If you want to talk about genotypes, you need to talk about haplotypes, then alleles.  What information do you want to send to make sure that the receiver has a complete picture.
+- Larry: So, technically, you could send a bundle without location information?
+- Reece: We should do what serves the broadest number of cases and worry about optimization later.  Sending partial packets is an optimization.
+- Larry:  Why is there no information model for sequences?
+- Reece: It is intentional and a slightly messy area.  There was a decision that we didn’t want to be another source of sequences.  We’re going to rely on a universe of sequences, so we need a way to name those.  Then wanting to come up with digests for variations, and make sure that those digests are based on underlying data, we needed a way to have an intrinsic identifier without a sequence.
+- Piotr: The same sequence can have different identifiers and alignments, so how can you have an information model based on the sequence?
+- Reece: Great point.  We don’t have any way to refer to alignments as first class objects.  We assume that a refseq id has an implied alignment to the genome.  NCBI doesn’t recognize that.  Have found the same versioned accession has multiple alignments to the genomes and has impacts on clinical interpretations to the genome.  Until we come to a point where we treat alignments as first class objects and digest them, we will always have implied information.
+- Chris: This suggests that alignments should be first class objects.
+- Reece: I hash alignments.
+- Larry: Should we deal with alignments as first class objects now or recognize it as something we deal with later?
+- Chris: One potential way to proceed is we are starting to get an idea of what the properties of the relationships are.  We’ll have to circle back around***
+- Reece: Equivalence function***  Alleles A and B could be equivalent under***
+- Chris: I would like to see alignments represented in the final outcome ***
+
+
+* [**Archive**](/variant_representation_minutes.html) of previous meeting minutes

--- a/_posts/2029-11-11-minutes-variant_representation-archive.md
+++ b/_posts/2029-11-11-minutes-variant_representation-archive.md
@@ -1,0 +1,21 @@
+---
+title:  "VarRep Minutes Archive"
+date: 2029-11-11
+layout: default
+permalink: /variant_representation_minutes.html
+category:
+  - variant_representation
+---
+
+## GA4GH::GKS Variant Representation Meeting Minutes
+
+Current meeting minutes are published accessible through [here](https://docs.google.com/document/d/1Sulg3kECnorTEAbutINOsK-lFkKAcKpl6IHgPaPQEgA) for review and comments. 
+
+### Archive
+
+{% for item in site.categories.variant_representation_minutes %}
+<div class="excerpt">
+{{ item.excerpt }}
+<p>{{ item.date | date: "%Y-%m-%d" }}: <a href="{{ item.url | relative_url }}">more ...</a></p>
+</div>
+{% endfor %}

--- a/variant_annotation.md
+++ b/variant_annotation.md
@@ -32,7 +32,7 @@ Conference calls are held remotely via Zoom Teleconferencing and can be joined u
 
 ## Documents
 
-|| Document Name || Purpose || 
+| Document Name | Purpose |
 |----------------|-----------|
 | [Roadmap](https://docs.google.com/document/d/1Hu1t_JPtm1T12M5iJVPsZxDvE-OJp-munyWh-S7vu68/edit ) | Details our future goals and timelines |
 | [Landscape Analysis](https://docs.google.com/spreadsheets/d/1BV0BuvdkobVAi3YLCzqUUqBGT-wM2jPfLvVQAF5IQcc/edit#gid=1171477640) | Known resources, data models, curation frameworks, applications and enums pertaining to variation annotation |

--- a/variant_annotation.md
+++ b/variant_annotation.md
@@ -6,4 +6,37 @@ category:
   - variant_annotation
 ---
 
-## GA4GH::GKS Variant Annotation
+# GA4GH::GKS Variant Annotation
+
+The Variant Annotation group aims to develop a common data model to represent annotations made on genomic variants, and the evidence and provenance that underlie these annotations. The model will support a wide variety of variant annotations, including causal association to disease/phenotype and interpretations of clinical relevance and actionability, and will support existing clinical lab standards such as the ACMG/AMP variant interpretation guidelines.
+
+## Leads
+
+* Matt Brush
+* Javier Lopez
+
+## Meetings
+
+Generally every Wednesday at 8am PST, 11am EST, 4pm GMT. Check the [calendar for updates](https://calendar.google.com/calendar/b/1?cid=Z2Vub21pY3NhbmRoZWFsdGgub3JnX2trZTc4cnBuZms0dGszdmNyam8wODUxcHEwQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20).
+
+Meeting minutes are published at https://docs.google.com/document/d/13sSChUB9rW7vl1ep-tZnaDzSWb_MyWIvSzEFVS32quE.
+
+Conference calls are held remotely via Zoom Teleconferencing and can be joined using the following methods:
+
+* PC, Mac, Linux, iOS or Android: https://zoom.us/j/7082943722
+* Telephone
+** US: 1 646 558 8656  
+** UK: (0) 20 3695 0088
+** International #s https://zoom.us/zoomconference
+** Meeting ID: 708 294 3722
+
+## Documents
+
+|| Document Name || Purpose || 
+|----------------|-----------|
+| [Roadmap](https://docs.google.com/document/d/1Hu1t_JPtm1T12M5iJVPsZxDvE-OJp-munyWh-S7vu68/edit ) | Details our future goals and timelines |
+| [Landscape Analysis](https://docs.google.com/spreadsheets/d/1BV0BuvdkobVAi3YLCzqUUqBGT-wM2jPfLvVQAF5IQcc/edit#gid=1171477640) | Known resources, data models, curation frameworks, applications and enums pertaining to variation annotation |
+| [Variant Annotation Definition and Categories](https://docs.google.com/document/d/1csUrC4kX6G1V1GIz07btQQ3oL_cdDPJShuauL_uCjEw/edit) | Defining what is variant annotation with respect to this workstream |
+| [Driver Project Data Overview](https://docs.google.com/document/d/1qRlDRXaKoeW8vWZ6meQBNutXsTIBqtQrf7B0IJ4JDNg/edit#heading=h.pd5a1roctmgj) | Summary data to model as defined by our engaged driver projects |
+| [Driver Project Data Evaluation](https://docs.google.com/document/d/1BbRfPyYH3aHGEK1QhoVRGQJtY9FkVF0GHdaSzez1Reo/edit#heading=h.gy3xodyz89u6) | Evalutation of examples of driver project variant annotation |
+| [Concept Glossary](https://docs.google.com/document/d/1zrOXzD08XletSHwrJHofkPufANkAy7marAkPyFX9AVY/edit) | Defining a set of concepts or terms clearly and to use them consistently |

--- a/variant_annotation.md
+++ b/variant_annotation.md
@@ -30,6 +30,10 @@ Conference calls are held remotely via Zoom Teleconferencing and can be joined u
   * International #s https://zoom.us/zoomconference
   * Meeting ID: 708 294 3722
 
+## Email Lists
+
+You can contact the variant representation group using the Google Group  https://groups.google.com/a/ga4gh.org/d/forum/ga4gh-variant-annotation.
+
 ## Documents
 
 | Document Name | Purpose |

--- a/variant_annotation.md
+++ b/variant_annotation.md
@@ -25,10 +25,10 @@ Conference calls are held remotely via Zoom Teleconferencing and can be joined u
 
 * PC, Mac, Linux, iOS or Android: https://zoom.us/j/7082943722
 * Telephone
-** US: 1 646 558 8656  
-** UK: (0) 20 3695 0088
-** International #s https://zoom.us/zoomconference
-** Meeting ID: 708 294 3722
+  * US: 1 646 558 8656  
+  * UK: (0) 20 3695 0088
+  * International #s https://zoom.us/zoomconference
+  * Meeting ID: 708 294 3722
 
 ## Documents
 

--- a/variant_representation.md
+++ b/variant_representation.md
@@ -7,13 +7,38 @@ category:
 ---
 
 ## GA4GH::GKS Variant Representation
+The Variant Representation group aims to develop a computational data model and message schema specification for the representation of variants, in data resources and for API generation. The initial implementation will build on the work of the VMC, and will gradually expand that schema to include support for structural and complex variants, as well as variation/allele equivalence. 
 
-* [Variant Representation Minutes](https://docs.google.com/document/d/1Sulg3kECnorTEAbutINOsK-lFkKAcKpl6IHgPaPQEgA/edit#)
+## Leads
 
-### Team Members
-
-* Melissa Konopko
 * Larry Babb
-* Michael Baudis ([UZH](http://www.imls.uzh.ch/en/research/baudis/) & [SIB](https://www.sib.swiss/baudis-michael/))
-* Cristina Y. Gonzalez
-* ...
+* Michael Baudis
+
+## Meetings
+
+Generally every Monday at 9am PST, 12pm EST, 5pm GMT. Check the [calendar for updates](https://calendar.google.com/calendar/b/1?cid=Z2Vub21pY3NhbmRoZWFsdGgub3JnX2trZTc4cnBuZms0dGszdmNyam8wODUxcHEwQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20).
+
+Meeting minutes are published at https://docs.google.com/document/d/1Sulg3kECnorTEAbutINOsK-lFkKAcKpl6IHgPaPQEgA.
+
+Conference calls are held remotely via Zoom Teleconferencing and can be joined using the following methods:
+
+* PC, Mac, Linux, iOS or Android: https://zoom.us/j/7082943722
+* Telephone
+  * US: 1 646 558 8656  
+  * UK: (0) 20 3695 0088
+  * International #s https://zoom.us/zoomconference
+  * Meeting ID: 708 294 3722
+
+## Email Lists
+
+You can contact the variant representation group using the Google Group https://groups.google.com/a/ga4gh.org/forum/#!forum/variant-rep.
+
+## Documents
+
+| Document Name | Purpose |
+|----------------|-----------|
+| [Roadmap](https://docs.google.com/document/d/1oKitY4lUu4Rq6Xx5dwI1REf3GTlYX8vzh_D0WJWxbvQ ) | Details our future goals and timelines |
+| [VMC Specification](https://docs.google.com/document/d/12E8WbQlvfZWk5NrxwLytmympPby6vsv60RxCeD5wc1E) | The VMC specification master document |
+| [Equivalence Use Cases](https://docs.google.com/document/d/1UTjAB-Nh2t7UCCTVl1VdoXTP8HK0Y4LmDEAvqUBMOOY) | Set of worked use-cases describing variation equivalence |
+| [Structural Variants Concepts](https://docs.google.com/document/d/19juHy7HUkAOACVHPVnWh033UwAjn0iwkoGA7THoZsgE) | Document defining the structure and format of strutural variants |
+| [Structural Variants Types Spreadsheet](https://docs.google.com/spreadsheets/d/17M1U3Qfw18fkA30SoH1vJyOEK_fZ0z54UKbNPsdr9h0) | Existing models of structural variants |

--- a/variant_representation.md
+++ b/variant_representation.md
@@ -18,7 +18,8 @@ The Variant Representation group aims to develop a computational data model and 
 
 Generally every Monday at 9am PST, 12pm EST, 5pm GMT. Check the [calendar for updates](https://calendar.google.com/calendar/b/1?cid=Z2Vub21pY3NhbmRoZWFsdGgub3JnX2trZTc4cnBuZms0dGszdmNyam8wODUxcHEwQGdyb3VwLmNhbGVuZGFyLmdvb2dsZS5jb20).
 
-Meeting minutes are published at https://docs.google.com/document/d/1Sulg3kECnorTEAbutINOsK-lFkKAcKpl6IHgPaPQEgA.
+Current meeting minutes are published accessible through [here](https://docs.google.com/document/d/1Sulg3kECnorTEAbutINOsK-lFkKAcKpl6IHgPaPQEgA) for review and comments. 
+* [Archive](/variant_representation_minutes.html) of previous meeting minutes
 
 Conference calls are held remotely via Zoom Teleconferencing and can be joined using the following methods:
 


### PR DESCRIPTION
This PR:

* integrates the edits from @andrewyatz 
* creates a new way to handle "minutes", which in this proposal will be created as file-per-meeting in the `_posts` directory, and automatically collated on an "... archive" page

As per email discussion, it seems a good way to have the meeting minutes (except the 1-2 most recent ones ...) removed from the single Google Docs file. This guarantees proper archiving, but also easy access for contributors & interested parties.

The current implementation just adds 2 files from recent minutes of the VarRep subgroup, and a landing/collation page. The minutes files themselves could need some nicer edits ... Also, I left out the tables.

So, if getting 2x "+1" here, we could:

* add the same structure for VarAnn (me...)
* migrate minutes from the Google Docs to separate, dated files in the `_posts` directory (FYI, this is a standard way for handling these kind of sites and works quite nicely...)

Example heading for a minutes file:

```
---
title:  "VarRep Minutes 2018-04-16"
date: 2018-04-16
layout: default
category:
  - variant_representation_minutes
---

## 2018-04-16 Var Rep Working Call (equiv/analog vmc examples)
##### Chairs: Larry Babb
##### Attendees “Name (Affiliation)”

* Michael Baudis
* Piotr Pawliczek (ClinGen)
* Andy Yates (EMBL-EBI)
```

Notes:
* the front matter (YAML syntax) is needed for processing, with per-document adjustments of date & title
* the `category` list here identifies the page as `variant_representation_minutes` file (would be e.g.`variant_annotation_minutes` for those ...)
* everything below the second `---` is standard Markdown (including the usual "insert HTML here" option)

![screen shot 2018-04-25 at 11 43 38](https://user-images.githubusercontent.com/675030/39266442-de5cfd98-487e-11e8-98f0-3f562a203447.png)
![screen shot 2018-04-25 at 11 44 09](https://user-images.githubusercontent.com/675030/39266467-ebaf5ca2-487e-11e8-8ab2-da8b27b1aea1.png)